### PR TITLE
Add 'go to core/install.php' to README.txt and add developer friendly settings to the defaullt. local.settings.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 1. Open web/sites/default/settings.local.php and adjust it
    to your local environment needs.
 1. Configure your web server so it points to the web directory.
-1. Open the site in a web browser.
+1. Open the site in a web browser and go to core/install.php.
 1. Select Config Installer as the installation profile.
 1. At the config import step, find and select the configuration
    file at config/config.tar.gz.

--- a/web/sites/default/default.settings.local.php
+++ b/web/sites/default/default.settings.local.php
@@ -22,3 +22,26 @@ $config_directories['sync'] = 'sites/default/files/config_42L9pXMBOiVVCE4Uwm980e
 
 // If you need to test the newsletter widget, set your Mailchimp API key below.
 $config['mailchimp.settings']['api_key'] = 'foo';
+
+/**
+ * Set development friendly settings and configurations.
+ *
+ * @see sites/example.settings.local.php
+ */
+assert_options(ASSERT_ACTIVE, TRUE);
+\Drupal\Component\Assertion\Handle::register();
+$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
+$config['system.logging']['error_level'] = 'verbose';
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+
+// Disable render cache. (Do not change until after the site is installed.)
+# $settings['cache']['bins']['render'] = 'cache.backend.null';
+
+// Disable Dynamic Page cache.
+# $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+$settings['extension_discovery_scan_tests'] = TRUE;
+$settings['rebuild_access'] = TRUE;
+$settings['skip_permissions_hardening'] = TRUE;
+


### PR DESCRIPTION
I've added some developer friendly options to default.settings.local.php (from example.settings.local.php), assuming that local is used for development. Also completed the README.md to point out that users have to go to core/install.php (index.php throws an error when using a settings.php with an empty DB, see https://www.drupal.org/node/728702